### PR TITLE
Update readme to transition the product-initiatives repo to the product-roadmap repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Initiatives are arranged on a project board with the following stages to give a 
 
 | Stage | Description | Activities |
 | --- | --- | --- |
-| **Now** | Initiatives currently being worked on | UI design, deployment plan, engineering specs, impact validation |
-| **Next** | Initiatives coming up soon | Defining product initiatives, and concept notes with partners | 
-| **Later** | Initiatives that we’d like to work on in the future but need to do more research before they are ready for prioritization | High-level concepts with lots of flexibility | 
+| **Now** | Initiatives currently being worked on | Design, development, and release of related features and improvements |
+| **Next** | Initiatives we'll likely be pursuing next | Scope out features and improvements with partners| 
+| **Later** | Initiatives we may take on later | Early exploration of high level requirements, as well as partners and funding opportunities | 
 
 ### Roadmap Communication
 Updated initiatives are communicated quarterly to the CHT Community on the [CHT Forum](https://forum.communityhealthtoolkit.org/c/product/roadmaps/25). Where possible, we will link to specific issues and/or documentation to elaborate on what was completed to move an initiative forward. 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We are iterating on the format of the roadmap, and we value the engagement of Co
 Product initiatives are specific areas to improve the CHT that align with its medium and long-term vision. Initiatives are often worked on over multiple releases. When an initiative is scheduled, an "initiative owner" is assigned. Their role is to flesh out the objectives of the initiative, and break it down into release-sized chunks that can be scheduled into upcoming releases. 
 
 ### Roadmap Stages
-The roadmap is arranged on a project board to give a sense for how far out each item is on the horizon. Every initiative is added to a particular project board column according to when it is expected to be worked on.  The roadmap is organized into “now” “next” and “later” categories to communicate the product areas that we are focused-on to solve core product challenges or harness opportunities:
+Initiatives are arranged on a project board with the following stages to give a sense for how far out each item is on the horizon:
 
 | Stage | Description | Activities |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# product-initiatives
-Repo for product owners and management team to organize product initiatives
+# CHT Product Roadmap
+In this repository, you can find the Community Health Toolkit product roadmap. The product roadmap serves as a plan for how the Community Health Toolkit will grow to realize our vision; it is where you can learn about what product initiatives we are working on and what stage they are in. Please note, the roadmap is subject to change, especially further out on the timeline.
 
-Product initiatives are bodies of work to improve the Core Framework and associated tools. Initiatives are added to the appropriate product backlog to help organize and communicate information to stakeholders. 
+We are iterating on the format of the roadmap, and we value the engagement of Community members to discuss the future of CHT features and functionality. Have any questions or comments about items on the roadmap or roadmap format? Join the discussion over on the [Community Health Toolkit Forum](https://forum.communityhealthtoolkit.org/c/product/roadmaps/25).
 
-An initiative can emanate from existing Github issues (ie to pull them together and contextualize) or from identified product opportunities without Github issues (ie to explore an area that could generate new product requirements). In either scenario, they will contain collections of user stories that help to align the team around a shared understanding of the requirements for individual personas. Issues that spawn from product initiatives are scheduled to one or multiple release cycles.
+## Guide to the Roadmap
+
+### What is a product initiative?
+Product initiatives are high-level priorities that are completed to make progress on a theme. Initiatives are often worked on over multiple releases. An initiative owner is assigned to each prioritized initiative to flesh out the initiative’s objective(s), draft a roadmap, and break it down into release-sized chunks that can be scheduled in a product release. 
+
+### Roadmap Stages
+The roadmap is arranged on a project board to give a sense for how far out each item is on the horizon. Every initiative is added to a particular project board column according to when it is expected to be worked on.  The roadmap is organized into “now” “next” and “later” categories to communicate the product areas that we are focused-on to solve core product challenges or harness opportunities:
+
+| Stage | Description | Activities |
+| --- | --- | --- |
+| **Now** | Initiatives currently being worked on | UI design, deployment plan, engineering specs, impact validation |
+| **Next** | Initiatives coming up soon | Defining product initiatives, and concept notes with partners | 
+| **Later** | Initiatives that we’d like to work on in the future but need to do more research before they are ready for prioritization | High-level concepts with lots of flexibility | 
+
+### Roadmap Communication
+Updated initiatives are communicated quarterly to the CHT Community on the [CHT Forum](https://forum.communityhealthtoolkit.org/c/product/roadmaps/25). Where possible, we will link to specific issues and/or documentation to elaborate on what was completed to move an initiative forward. 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ We are iterating on the format of the roadmap, and we value the engagement of Co
 
 ## Guide to the Roadmap
 
-### What is a product initiative?
+### What is a Product Initiative?
 Product initiatives are high-level priorities that are completed to make progress on a theme. Initiatives are often worked on over multiple releases. An initiative owner is assigned to each prioritized initiative to flesh out the initiative’s objective(s), draft a roadmap, and break it down into release-sized chunks that can be scheduled in a product release. 
 
 ### Roadmap Stages

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We are iterating on the format of the roadmap, and we value the engagement of Co
 ## Guide to the Roadmap
 
 ### What is a Product Initiative?
-Product initiatives are high-level priorities that are completed to make progress on a theme. Initiatives are often worked on over multiple releases. An initiative owner is assigned to each prioritized initiative to flesh out the initiative’s objective(s), draft a roadmap, and break it down into release-sized chunks that can be scheduled in a product release. 
+Product initiatives are specific areas to improve the CHT that align with its medium and long-term vision. Initiatives are often worked on over multiple releases. When an initiative is scheduled, an "initiative owner" is assigned. Their role is to flesh out the objectives of the initiative, and break it down into release-sized chunks that can be scheduled into upcoming releases. 
 
 ### Roadmap Stages
 The roadmap is arranged on a project board to give a sense for how far out each item is on the horizon. Every initiative is added to a particular project board column according to when it is expected to be worked on.  The roadmap is organized into “now” “next” and “later” categories to communicate the product areas that we are focused-on to solve core product challenges or harness opportunities:


### PR DESCRIPTION
@abbyad this is a draft for updating the current product-initiatives repo to be the product-roadmap repo.  For a visual of what I am going for, I am following a similar format to [GitHub](https://github.com/github/roadmap/projects/1). Please add your comments and I will start reorganizing the issues in the repo to reflect these changes.